### PR TITLE
Rework websocket and add cancellation

### DIFF
--- a/standard-constraints/src/chess_constraint.rs
+++ b/standard-constraints/src/chess_constraint.rs
@@ -112,7 +112,7 @@ mod test {
             .build()
             .unwrap();
 
-        let solution_count = solver.find_solution_count(10000, None);
+        let solution_count = solver.find_solution_count(10000, None, None);
         assert!(solution_count.is_exact_count());
         assert_eq!(solution_count.count().unwrap(), 4);
     }
@@ -132,7 +132,7 @@ mod test {
                 .build()
                 .unwrap();
 
-            let solution_count = solver.find_solution_count(10000, None);
+            let solution_count = solver.find_solution_count(10000, None, None);
             assert!(solution_count.is_exact_count());
             assert_eq!(solution_count.count().unwrap(), 1);
         }

--- a/standard-constraints/src/fpuzzles_parser.rs
+++ b/standard-constraints/src/fpuzzles_parser.rs
@@ -431,7 +431,7 @@ mod test {
 
         let board = FPuzzlesBoard::from_lzstring_json(lzstring).unwrap();
         let solver = parser.parse_board(&board, false).unwrap();
-        let count = solver.find_solution_count(10000, Some(&mut receiver));
+        let count = solver.find_solution_count(10000, Some(&mut receiver), None);
         assert!(count.is_exact_count());
         assert_eq!(count.count().unwrap(), 1);
         assert_eq!(receiver.solution.unwrap(), expected_solution);

--- a/standard-constraints/src/message_handler.rs
+++ b/standard-constraints/src/message_handler.rs
@@ -130,7 +130,7 @@ impl MessageHandler {
         let real_cells: Vec<ValueMask>;
         let mut candidate_counts: Option<Vec<usize>> = None;
         if colored {
-            let result = solver.find_true_candidates_with_count(8);
+            let result = solver.find_true_candidates_with_count(8, self.cancellation.clone());
             match result {
                 TrueCandidatesCountResult::None => {
                     return InvalidResponse::new(nonce, "No solutions found.").to_json();
@@ -212,11 +212,12 @@ impl MessageHandler {
     }
 
     fn count(&mut self, nonce: i32, solver: Solver, max_solutions: i32) -> String {
+        let cancellation = self.cancellation.clone();
         let result = if max_solutions > 0 && max_solutions <= 2 {
-            solver.find_solution_count(max_solutions as usize, None)
+            solver.find_solution_count(max_solutions as usize, None, cancellation)
         } else {
             let mut receiver = ReportCountSolutionReceiver::new(nonce, self);
-            solver.find_solution_count(0, Some(&mut receiver))
+            solver.find_solution_count(0, Some(&mut receiver), cancellation)
         };
         match result {
             SolutionCountResult::None => {

--- a/standard-constraints/src/message_handler.rs
+++ b/standard-constraints/src/message_handler.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 use crate::prelude::*;
 use itertools::Itertools;
 use sudoku_solver_lib::prelude::*;
+use sudoku_solver_lib::solver::cancellation::Cancellation;
 
 use self::message::*;
 use self::responses::*;
@@ -15,12 +16,16 @@ pub trait SendResult {
 }
 
 pub struct MessageHandler {
-    pub send_result: Box<dyn SendResult>,
+    send_result: Box<dyn SendResult>,
+    cancellation: Cancellation,
 }
 
 impl MessageHandler {
-    pub fn new(send_result: Box<dyn SendResult>) -> Self {
-        Self { send_result }
+    pub fn new(send_result: Box<dyn SendResult>, cancellation: impl Into<Cancellation>) -> Self {
+        Self {
+            send_result,
+            cancellation: cancellation.into(),
+        }
     }
 
     fn send_result(&mut self, result: &str) {
@@ -369,7 +374,7 @@ mod test {
     fn create_test_handler() -> (MessageHandler, Rc<RefCell<Vec<String>>>) {
         let results = Rc::new(RefCell::new(Vec::new()));
         let test_handler = Box::new(TestSendResult::new(results.clone()));
-        (MessageHandler::new(test_handler), results)
+        (MessageHandler::new(test_handler, None), results)
     }
 
     #[test]

--- a/standard-constraints/src/message_handler/message.rs
+++ b/standard-constraints/src/message_handler/message.rs
@@ -4,8 +4,9 @@ use serde::*;
 pub(crate) struct Message {
     nonce: i32,
     command: String,
-    #[serde(rename = "dataType")]
+    #[serde(rename = "dataType", default)]
     data_type: String,
+    #[serde(default)]
     data: String,
 }
 

--- a/standard-constraints/src/non_repeat_constraint.rs
+++ b/standard-constraints/src/non_repeat_constraint.rs
@@ -79,7 +79,7 @@ mod test {
             .build()
             .unwrap();
         assert_eq!(solver.board().houses().len(), 29);
-        let solution_count = solver.find_solution_count(10000, None);
+        let solution_count = solver.find_solution_count(10000, None, None);
         assert!(solution_count.is_exact_count());
         assert_eq!(solution_count.count().unwrap(), 2);
     }

--- a/standard-constraints/src/orthogonal_pairs_constraint.rs
+++ b/standard-constraints/src/orthogonal_pairs_constraint.rs
@@ -291,7 +291,7 @@ mod test {
             .build()
             .unwrap();
 
-        let solution_count = solver.find_solution_count(10000, None);
+        let solution_count = solver.find_solution_count(10000, None, None);
         assert!(solution_count.is_exact_count());
         assert_eq!(solution_count.count().unwrap(), 8448);
     }
@@ -314,7 +314,7 @@ mod test {
             .build()
             .unwrap();
 
-        let solution_count = solver.find_solution_count(2, None);
+        let solution_count = solver.find_solution_count(2, None, None);
         assert!(solution_count.is_exact_count());
         assert_eq!(solution_count.count().unwrap(), 1);
     }

--- a/sudoku-solver-console/src/listener/ws.rs
+++ b/sudoku-solver-console/src/listener/ws.rs
@@ -1,17 +1,22 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
 use super::client::Client;
 use super::Clients;
 use futures::{FutureExt, StreamExt};
 use standard_constraints::message_handler::*;
-use tokio::{runtime::Handle, sync::mpsc};
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio::sync::mpsc::{self, Sender};
+use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 use warp::ws::{Message, WebSocket};
 
 pub async fn client_connection(ws: WebSocket, clients: Clients) {
     let (client_ws_sender, mut client_ws_rcv) = ws.split();
-    let (client_sender, client_rcv) = mpsc::unbounded_channel();
+    let (client_sender, client_rcv) = mpsc::channel(5);
 
-    let client_rcv = UnboundedReceiverStream::new(client_rcv);
+    let client_rcv = ReceiverStream::new(client_rcv);
 
     tokio::task::spawn(client_rcv.forward(client_ws_sender).map(|result| {
         if let Err(e) = result {
@@ -23,12 +28,15 @@ pub async fn client_connection(ws: WebSocket, clients: Clients) {
 
     let new_client = Client {
         client_id: uuid.clone(),
-        sender: Some(client_sender),
+        sender: None,
     };
 
     clients.lock().await.insert(uuid.clone(), new_client);
 
     println!("Client {} connected", uuid);
+
+    let mut handler = ThreadedHandler::new(client_sender.clone()).await;
+
     while let Some(result) = client_ws_rcv.next().await {
         let msg = match result {
             Ok(msg) => msg,
@@ -37,54 +45,109 @@ pub async fn client_connection(ws: WebSocket, clients: Clients) {
                 break;
             }
         };
-        client_msg(&uuid, msg, &clients).await;
+
+        if !handler.is_ready() {
+            handler.cancel().await;
+            handler = ThreadedHandler::new(client_sender.clone()).await;
+        }
+
+        if handler.send(msg).await.is_err() {
+            break;
+        }
     }
+
+    handler.cancel().await;
 
     clients.lock().await.remove(&uuid);
     println!("Client {} Disconnected", uuid);
 }
 
-struct SendResultWS {
-    clients: Clients,
-    client_id: String,
+struct SendResultForWS {
+    sender: Sender<Result<Message, warp::Error>>,
 }
 
-impl SendResultWS {
-    fn new(clients: Clients, client_id: String) -> Self {
-        Self { clients, client_id }
+impl SendResultForWS {
+    fn new(sender: Sender<Result<Message, warp::Error>>) -> Self {
+        Self { sender }
     }
 }
 
-impl SendResult for SendResultWS {
+impl SendResult for SendResultForWS {
+    /// Panics if we cannot send, which will terminate the thread
     fn send_result(&mut self, result: &str) {
-        let handle = Handle::current();
-        let _ = handle.enter();
-        futures::executor::block_on(async {
-            let locked = self.clients.lock().await;
-            match locked.get(&self.client_id) {
-                Some(v) => {
-                    if let Some(sender) = &v.sender {
-                        let _ = sender.send(Ok(Message::text(result)));
-                    }
+        self.sender
+            .blocking_send(Ok(Message::text(result)))
+            .unwrap();
+    }
+}
+
+struct ThreadedHandler {
+    join_handle: std::thread::JoinHandle<()>,
+    sender: Sender<Message>,
+    cancel_token: Arc<AtomicBool>,
+    ready_token: Arc<AtomicBool>,
+}
+
+impl ThreadedHandler {
+    async fn new(client_sender: Sender<Result<Message, warp::Error>>) -> Self {
+        let (handler_sender, mut handler_recv) = mpsc::channel::<Message>(5);
+        let cancel_token = Arc::new(AtomicBool::from(false));
+        let ready_token = Arc::new(AtomicBool::new(true));
+
+        let joiner = std::thread::spawn({
+            let cancel_token = Arc::clone(&cancel_token);
+            let ready_token = Arc::clone(&ready_token);
+            move || {
+                // This is the thread for handling messages from the client.
+                // We handle multiple messages before we give up
+                let mut message_handler =
+                    MessageHandler::new(Box::new(SendResultForWS::new(client_sender)));
+                while let Some(message) = handler_recv.blocking_recv() {
+                    let message = match message.to_str() {
+                        Ok(v) => v.to_string(),
+                        Err(_) => break,
+                    };
+                    ready_token.store(false, Ordering::SeqCst);
+                    message_handler.handle_message(&message);
+                    ready_token.store(true, Ordering::SeqCst);
                 }
-                None => return,
             }
         });
+
+        ThreadedHandler {
+            join_handle: joiner,
+            sender: handler_sender,
+            cancel_token,
+            ready_token,
+        }
     }
-}
 
-async fn client_msg(client_id: &str, msg: Message, clients: &Clients) {
-    let message = match msg.to_str() {
-        Ok(v) => v.to_string(),
-        Err(_) => return,
-    };
+    async fn send(&self, message: Message) -> Result<(), mpsc::error::SendError<Message>> {
+        self.sender.send(message).await
+    }
 
-    let client_id = client_id.to_owned();
-    let clients = clients.clone();
-    let _ = tokio::task::spawn_blocking(move || {
-        let send_result = Box::new(SendResultWS::new(clients, client_id));
-        let mut message_handler = MessageHandler::new(send_result);
-        message_handler.handle_message(&message);
-    })
-    .await;
+    async fn cancel(self) {
+        let Self {
+            join_handle,
+            sender,
+            cancel_token,
+            ready_token,
+        } = self;
+        cancel_token.store(true, Ordering::SeqCst);
+        drop(sender);
+        drop(ready_token);
+        let mut counter = 0;
+        const MAX_COUNT: usize = 100;
+        while counter < MAX_COUNT && !join_handle.is_finished() {
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            counter += 1;
+        }
+        if counter == MAX_COUNT {
+            println!("Handler thread didn't stop in time, CPU may be wasted for a while");
+        }
+    }
+
+    fn is_ready(&self) -> bool {
+        self.ready_token.load(Ordering::SeqCst)
+    }
 }

--- a/sudoku-solver-lib/src/solver.rs
+++ b/sudoku-solver-lib/src/solver.rs
@@ -1,5 +1,6 @@
 //! Constains the [`Solver`] struct which is the main entry point for solving a puzzle.
 
+pub mod cancellation;
 pub mod logical_solve_result;
 pub mod prelude;
 pub mod single_solution_result;

--- a/sudoku-solver-lib/src/solver/cancellation.rs
+++ b/sudoku-solver-lib/src/solver/cancellation.rs
@@ -1,12 +1,16 @@
 //! Cancelling various solver operations requires a [`Cancellation`].
 
+use std::sync::Arc;
+
 /// A Cancellation embodies a check for whether or not to abort a solve process
 ///
 /// If you do not want to provide a cancellation, then most solver methods
-/// take an `Option<Cancellation>` anyway.
-
+/// take an `impl Into<Cancellation>` which you can give `None` to.
+///
+/// This object is an Arc internally and so very cheap to clone
+#[derive(Clone)]
 pub struct Cancellation {
-    func: Box<dyn Fn() -> bool>,
+    func: Arc<dyn Fn() -> bool>,
 }
 
 impl Cancellation {
@@ -33,7 +37,7 @@ impl Cancellation {
         F: (Fn() -> bool) + 'static,
     {
         Self {
-            func: Box::new(func),
+            func: Arc::new(func),
         }
     }
 
@@ -49,7 +53,7 @@ where
 {
     fn from(func: F) -> Self {
         Self {
-            func: Box::new(func),
+            func: Arc::new(func),
         }
     }
 }

--- a/sudoku-solver-lib/src/solver/cancellation.rs
+++ b/sudoku-solver-lib/src/solver/cancellation.rs
@@ -1,0 +1,61 @@
+//! Cancelling various solver operations requires a [`Cancellation`].
+
+/// A Cancellation embodies a check for whether or not to abort a solve process
+///
+/// If you do not want to provide a cancellation, then most solver methods
+/// take an `Option<Cancellation>` anyway.
+
+pub struct Cancellation {
+    func: Box<dyn Fn() -> bool>,
+}
+
+impl Cancellation {
+    /// Create a new Cancellation from a checking function
+    ///
+    /// ```
+    /// # use sudoku_solver_lib::solver::cancellation::Cancellation;
+    /// # use std::sync::Arc;
+    /// # use std::sync::atomic::AtomicBool;
+    /// # use std::sync::atomic::Ordering;
+    ///
+    /// let cancel_token = Arc::new(AtomicBool::from(false));
+    /// let cancellation = Cancellation::new({
+    ///     let cancel_token = Arc::clone(&cancel_token);
+    ///     move || cancel_token.load(Ordering::SeqCst)
+    /// });
+    ///
+    /// assert_eq!(cancellation.check(), false);
+    /// cancel_token.store(true, Ordering::SeqCst);
+    /// assert_eq!(cancellation.check(), true);
+    /// ```
+    pub fn new<F>(func: F) -> Self
+    where
+        F: (Fn() -> bool) + 'static,
+    {
+        Self {
+            func: Box::new(func),
+        }
+    }
+
+    /// Check if the cancellation has been sent
+    pub fn check(&self) -> bool {
+        (self.func)()
+    }
+}
+
+impl<F> From<F> for Cancellation
+where
+    F: (Fn() -> bool) + 'static,
+{
+    fn from(func: F) -> Self {
+        Self {
+            func: Box::new(func),
+        }
+    }
+}
+
+impl From<Option<Cancellation>> for Cancellation {
+    fn from(c: Option<Cancellation>) -> Self {
+        c.unwrap_or_else(|| Cancellation::new(|| false))
+    }
+}

--- a/sudoku-solver-wasm/src/lib.rs
+++ b/sudoku-solver-wasm/src/lib.rs
@@ -32,6 +32,6 @@ impl SendResult for SendResultWasm {
 #[wasm_bindgen]
 pub fn solve(message: &str, receive_result: &js_sys::Function) {
     let send_result = Box::new(SendResultWasm::new(receive_result));
-    let mut message_handler = MessageHandler::new(send_result);
+    let mut message_handler = MessageHandler::new(send_result, None);
     message_handler.handle_message(message);
 }


### PR DESCRIPTION
This adds cancellation to the solver, and shows how to implement it for a couple of the solver functions (counting solutions, and true candidates).

In addition, this reworks the websocket handler to put the solver into a thread, and to try and deal with cancellation gracefully.

There may be some debug `println!()`s lying around, but I've set the PR to permit edits by maintainers.
